### PR TITLE
new_frames always has 1 extra frame than input_frames

### DIFF
--- a/source/DecoderNormalisationImplementation.cpp
+++ b/source/DecoderNormalisationImplementation.cpp
@@ -193,6 +193,7 @@ void DecoderNormalisationImplementation::decode(long frames,
           float *resampled_output = (float *)malloc(resampled_output_size);
           if (new_frames - 1 == input_frames) {
             memcpy(resampled_output, channel_samples, resampled_output_size);
+            new_frames = input_frames;
           } else {
             bool eof = strong_this->_wrapped_decoder->eof();
             size_t old_channel_samples_size = input_frames * sizeof(float);

--- a/source/DecoderNormalisationImplementation.cpp
+++ b/source/DecoderNormalisationImplementation.cpp
@@ -191,7 +191,7 @@ void DecoderNormalisationImplementation::decode(long frames,
           auto resampled_output_samples = new_frames * strong_this->channels();
           size_t resampled_output_size = resampled_output_samples * sizeof(float);
           float *resampled_output = (float *)malloc(resampled_output_size);
-          if (new_frames == input_frames) {
+          if (new_frames - 1 == input_frames) {
             memcpy(resampled_output, channel_samples, resampled_output_size);
           } else {
             bool eof = strong_this->_wrapped_decoder->eof();


### PR DESCRIPTION
* We need to consider this when doing a standard memcpy